### PR TITLE
Clean up workshop header includes and modernize aligned_allocator

### DIFF
--- a/workshop/include/workshop.h
+++ b/workshop/include/workshop.h
@@ -1,15 +1,14 @@
 #ifndef workshop_h
 #define workshop_h
 
-#include <iostream>
-#include <vector>
-#include <tuple>
-#include <cmath>
 #include <chrono>
-#include <string>
-#include <fstream>
-#include <random>
-#include <cstdint>
+#include <cmath>
+#include <cstddef>
+#include <cstdlib>
+#include <iostream>
+#include <new>
+#include <stdexcept>
+#include <vector>
 
 #if defined(__INTEL_COMPILER)
 #include <malloc.h>
@@ -69,6 +68,7 @@ class aligned_allocator
  
 		bool operator!=(const aligned_allocator& other) const
 		{
+			(void)other;
 			return !(*this == other);
 		}
  
@@ -89,6 +89,7 @@ class aligned_allocator
 		// Always returns true for stateless allocators.
 		bool operator==(const aligned_allocator& other) const
 		{
+			(void)other;
 			return true;
 		}
  
@@ -114,7 +115,7 @@ class aligned_allocator
 			// in which case the bad_alloc check below would fire).
 			// All allocators can return NULL in this case.
 			if (n == 0) {
-				return NULL;
+				return nullptr;
 			}
  
 			// All allocators should contain an integer overflow check.
@@ -129,7 +130,7 @@ class aligned_allocator
 			void * const pv = _mm_malloc(n * sizeof(T), Alignment);
  
 			// Allocators should throw std::bad_alloc in the case of memory allocation failure.
-			if (pv == NULL)
+			if (pv == nullptr)
 			{
 				throw std::bad_alloc();
 			}
@@ -139,6 +140,7 @@ class aligned_allocator
  
 		void deallocate(T * const p, const std::size_t n) const
 		{
+			(void)n;
 			_mm_free(p);
 		}
  
@@ -305,4 +307,3 @@ public:
 } // end of namespace workshop
 
 #endif
-


### PR DESCRIPTION
### Motivation
- Reduce unused includes and silence allocator-related warnings while keeping behavior unchanged by modernizing pointer/null handling and documenting required headers.

### Description
- Replace a number of unused includes with a minimal set (`<chrono>`, `<cmath>`, `<cstddef>`, `<cstdlib>`, `<iostream>`, `<new>`, `<stdexcept>`, `<vector>`), replace legacy `NULL` with `nullptr`, and mark unused parameters with `(void)` in `aligned_allocator` methods to avoid warnings.

### Testing
- Compiled and ran the example program with `g++ -std=c++17 -Iworkshop/include workshop/test.cpp -o /tmp/workshop_test` and executed `/tmp/workshop_test | head`, both commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aafb79b434832ebfc87b2de2fe87f1)